### PR TITLE
config: add sasl option to the config

### DIFF
--- a/config.json.dist
+++ b/config.json.dist
@@ -7,10 +7,12 @@
   "server": "irc.freenode.net",
   "ssl": false,
   "port": 6667,
+  "sasl": false,
   "flood": {
     "protection": true,
     "delay": 500
   },
+  "debug": false,
   "api_keys": {
     "imgur_client_id" : "62cfa9f704c3945"
   }

--- a/index.js
+++ b/index.js
@@ -45,7 +45,12 @@ client = new irc.Client(config.server, config.botName, {
     floodProtection: config.flood.protection,
     floodProtectionDelay: config.flood.delay,
     secure: config.ssl,
-    port: config.port
+    sasl: config.sasl,
+    userName: config.botName,
+    password: config.password,
+    port: config.port,
+    messageSplit: 1024,
+    encoding: "UTF-8"
 })
 
 each(config.channels, function(channel){


### PR DESCRIPTION
Add the possibility to login to the server using SASL authentification.

SASL authentification also require to pass the username and password to the server. [see node-irc doc](http://node-irc.readthedocs.org/en/latest/API.html)
> Set sasl to true to enable SASL support. You’ll also want to set nick, userName, and password for authentication.

Using SASL authentication it's now possible for the bot to join a channel with r mode (block unidentified).