### PR TITLE
listeners: add IMDB listener

### DIFF
--- a/listeners/imdb.js
+++ b/listeners/imdb.js
@@ -1,0 +1,67 @@
+var http = require('http')
+
+;(function(listener) {
+
+  var _underscore = /_/g
+    listener.matcher = function(message, envelope) {
+      return (envelope.type == 'channel') &&
+        message.search('imdb.com') !== -1
+    }
+
+  listener.callback = function(message, envelope) {
+    var pattern = RegExp('https?://(?:www\\.)imdb\.com/title/([^/]+)/'),
+    match = message.match(pattern),
+    url = "http://www.myapifilms.com/imdb?format=JSON&lang=en-us&actors=S&idIMDB=",
+    idIMDB,
+    self = this
+
+    if (match) {
+      idIMDB = decodeURIComponent(match[1].replace(_underscore, ' ')),
+      url += idIMDB
+
+      http.get(url, function(response) {
+        var json = ''
+
+        response.on("error", function(error) {
+          console.error('Error: ' + util.inspect(error))
+        })
+
+        response.on("data", function(chunk) {
+          json += chunk
+        })
+
+        response.on("end", function() {
+          var res = JSON.parse(json.trim()),
+              i,
+              reply = ''
+
+          if (res.title) {
+            reply += '↳ ' + res.title
+          }
+
+          if (res.year) {
+            reply += ' (' + res.year + ') '
+          }
+
+          if (res.rating) {
+            reply += res.rating + '★ '
+          }
+
+          if (res.actors) {
+            reply += ' - '
+            for (i = 0; i < 3; i++) {
+              if (res.actors[i]) {
+                reply += res.actors[i].actorName + ', '
+              }
+            }
+          }
+
+          if (reply) {
+            self.reply(envelope, reply)
+          }
+
+        })
+      })
+    }
+  }
+})(exports)

--- a/listeners/imdb.js
+++ b/listeners/imdb.js
@@ -9,7 +9,7 @@ var http = require('http')
     }
 
   listener.callback = function(message, envelope) {
-    var pattern = RegExp('https?://(?:www\\.)imdb\.com/title/([^/]+)/'),
+    var pattern = RegExp('https?://(?:www\\.)imdb\.com/title/([^/]+)/?'),
     match = message.match(pattern),
     url = "http://www.myapifilms.com/imdb?format=JSON&lang=en-us&actors=S&idIMDB=",
     idIMDB,


### PR DESCRIPTION
Add an IMDB listener that catch imdb link and display somes infos regarding the movies
As IMDB no longer have a plublic API we use http://www.myapifilms.com/.

We extract the IMDB id from a link, example `http://www.imdb.com/title/tt1567432/` to perform a request
`http://www.myapifilms.com/imdb?format=JSON&lang=en-us&actors=S&idIMDB=tt1567432`

The listener only display the title, year, rating and the first 3 actors of the movie/tv show.

As some link may refer to upcoming movies (without known title, year, rating or cast) I had to handle it using if blocks, but it doesn't really looks nice.

Example result
> ↳ Teen Wolf (2011– ) 7.8★  - Tyler Posey, Dylan O'Brien, Holland Roden,
