### PR TITLE
listeners: add imgur listener

### DIFF
--- a/config.json.dist
+++ b/config.json.dist
@@ -11,5 +11,7 @@
     "protection": true,
     "delay": 500
   },
-  "api_key": "SEKRET"
+  "api_keys": {
+    "imgur_client_id" : "62cfa9f704c3945"
+  }
 }

--- a/listeners/imgur.js
+++ b/listeners/imgur.js
@@ -1,0 +1,65 @@
+var https = require('https'),
+    fs   = require('fs'),
+    config
+
+if (fs.existsSync('config.json')) {
+  config = JSON.parse(fs.readFileSync('config.json'))
+}
+
+;(function(listener) {
+
+  listener.matcher = function(message, envelope) {
+    return (envelope.type == 'channel') &&
+      message.search('imgur.com') !== -1
+  }
+
+  listener.callback = function(message, envelope) {
+    var pattern = RegExp('https?://(?:www\.)?imgur\.com/gallery/([^/]+)/?'),
+        match = message.match(pattern),
+        options,
+        idImage,
+        self = this
+
+    if (match) {
+      idImage = match[1],
+      options = {
+        host: 'api.imgur.com',
+        path: '/3/image/' + idImage,
+        port: "443",
+        headers : {
+          "Authorization" : "Client-ID " + config.api_keys.imgur_client_id,
+          "Content-Type" : "application/json"
+        }
+      }
+
+      https.get(options, function(response) {
+        var json = ''
+
+        response.on("error", function(error) {
+          console.error('Error: ' + util.inspect(error))
+        })
+
+        response.on("data", function(chunk) {
+          json += chunk
+        })
+
+        response.on("end", function() {
+          var res = JSON.parse(json.trim()),
+              reply = ''
+
+          if (res.status == 200) {
+            reply += '↳ ' + res.data.title
+            if (res.data.nsfw) {
+              reply += ' (NSFW)'
+            }
+          }
+
+          if (reply) {
+            self.reply(envelope, reply)
+          }
+
+        })
+      })
+    }
+  }
+})(exports)


### PR DESCRIPTION
Add a Imgur listener to catch imgur URL and display if the image is tagged as NSFW.

Imgur require an authentication through https using a client id to access read only informations.

I added the key I got on the config sample.
The listener parse (again) the config to get the key (while the [giphy](https://github.com/putaindecode/ed-209/blob/master/listeners/giphy.js) listener use a hardcoded key).

So far it only handle URL with a format http://www.imgur.com/gallery/ID but I'm looking to extend it to i.imgur.com and the other variants of imgur URL.

Example:
> http://imgur.com/gallery/N9TNuy6
> ↳ null (NSFW)

Imgur API: https://api.imgur.com/